### PR TITLE
Remove invalid parameters

### DIFF
--- a/JiraPS/JiraPS.psd1
+++ b/JiraPS/JiraPS.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'JiraPS.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '891.1.0.0'
+    ModuleVersion     = '891.1.1.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -124,6 +124,8 @@
     # DefaultCommandPrefix = ''
 
 }
+
+
 
 
 

--- a/JiraPS/Public/Get-JiraPermissionScheme.ps1
+++ b/JiraPS/Public/Get-JiraPermissionScheme.ps1
@@ -47,7 +47,7 @@ function Get-JiraPermissionScheme {
 
     begin {
         Write-Debug "[Get-JiraPermissionScheme] Reading server from config file"
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
 
         Write-Debug "[Get-JiraPermissionScheme] ParameterSetName=$($PSCmdlet.ParameterSetName)"
 

--- a/JiraPS/Public/Get-JiraWorkflow.ps1
+++ b/JiraPS/Public/Get-JiraWorkflow.ps1
@@ -32,7 +32,7 @@
 
     begin
     {
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
         $restUri = "$server/rest/api/2/workflow"
     }
 

--- a/JiraPS/Public/Get-JiraWorkflowScheme.ps1
+++ b/JiraPS/Public/Get-JiraWorkflowScheme.ps1
@@ -35,7 +35,7 @@
 
     begin
     {
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
         $restUrl = "$server/rest/api/2/workflowscheme/$ID"
     }
 

--- a/JiraPS/Public/New-JiraPermissionScheme.ps1
+++ b/JiraPS/Public/New-JiraPermissionScheme.ps1
@@ -36,7 +36,7 @@ function New-JiraPermissionScheme
 
     begin
     {
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
         $restUri = "$server/rest/api/2/permissionscheme"
     }
 

--- a/JiraPS/Public/New-JiraProject.ps1
+++ b/JiraPS/Public/New-JiraProject.ps1
@@ -82,7 +82,7 @@ function New-JiraProject
     begin
     {
         Write-Debug -Message '[New-JiraProject] Reading information from config file'
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
 
         $uri = "$server/rest/api/2/project"
     }

--- a/JiraPS/Public/Remove-JiraPermissionScheme.ps1
+++ b/JiraPS/Public/Remove-JiraPermissionScheme.ps1
@@ -36,7 +36,7 @@ function Remove-JiraPermissionScheme {
     )
 
     begin {
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
         $restUri = "$server/rest/api/2/permissionscheme"
     }
 

--- a/JiraPS/Public/Remove-JiraProject.ps1
+++ b/JiraPS/Public/Remove-JiraProject.ps1
@@ -35,7 +35,7 @@ function Remove-JiraProject {
         Write-Debug "[Remove-JiraProject] Reading information from config file"
         try {
             Write-Debug "[Remove-JiraProject] Reading Jira server from config file"
-            $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+            $server = Get-JiraConfigServer -ErrorAction Stop
         }
         catch {
             $err = $_

--- a/JiraPS/Public/Remove-JiraWorkflowScheme.ps1
+++ b/JiraPS/Public/Remove-JiraWorkflowScheme.ps1
@@ -39,7 +39,7 @@
     )
 
     begin {
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
         if ($Force) {
             $oldConfirmPreference = $ConfirmPreference
             $ConfirmPreference = 'None'

--- a/JiraPS/Public/Set-JiraProject.ps1
+++ b/JiraPS/Public/Set-JiraProject.ps1
@@ -94,7 +94,7 @@ function Set-JiraProject
 
     begin
     {
-        $server = Get-JiraConfigServer -ConfigFile $ConfigFile -ErrorAction Stop
+        $server = Get-JiraConfigServer -ErrorAction Stop
     }
     process
     {

--- a/docs/en-US/Get-JiraConfigServer.md
+++ b/docs/en-US/Get-JiraConfigServer.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Get-JiraConfigServer [[-ConfigFile] <String>] [<CommonParameters>]
+Get-JiraConfigServer [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,21 +29,6 @@ PS C:\> {{ Add example code here }}
 {{ Add example description here }}
 
 ## PARAMETERS
-
-### -ConfigFile
-{{Fill ConfigFile Description}}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/en-US/Set-JiraConfigServer.md
+++ b/docs/en-US/Set-JiraConfigServer.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Set-JiraConfigServer [-Server] <Uri> [[-ConfigFile] <String>] [<CommonParameters>]
+Set-JiraConfigServer [-Server] <Uri> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,21 +29,6 @@ PS C:\> {{ Add example code here }}
 {{ Add example description here }}
 
 ## PARAMETERS
-
-### -ConfigFile
-{{Fill ConfigFile Description}}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Server
 {{Fill Server Description}}

--- a/docs/en-US/commands/Get-JiraConfigServer.md
+++ b/docs/en-US/commands/Get-JiraConfigServer.md
@@ -17,7 +17,7 @@ Obtains the configured URL for the JIRA server
 ## SYNTAX
 
 ```
-Get-JiraConfigServer [[-ConfigFile] <String>] [<CommonParameters>]
+Get-JiraConfigServer [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/en-US/commands/Set-JiraConfigServer.md
+++ b/docs/en-US/commands/Set-JiraConfigServer.md
@@ -36,14 +36,12 @@ This example defines the server URL of the JIRA server configured for the JiraPS
 
 ## PARAMETERS
 
-### -ConfigFile
+### -Server
 
-Path where the file with the configuration will be stored.
-
-> This parameter is not yet implemented
+The server URL that will be stored in the configuration file.
 
 ```yaml
-Type: String
+Type: Uri
 Parameter Sets: (All)
 Aliases:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->

### Description

This pull request removes every instance of an invalid `-ConfigFile` parameter, and updates the help files to reflect the current parameter set.

### Motivation and Context

After merging the latest version of JiraPS, it looks like some of our existing functions are calling both Get-JiraConfigServer and Set-JiraConfigServer with invalid parameters, causing them both to throw errors.

Closes #1 

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
